### PR TITLE
fix(auth): update GraphQLError import for ESM compatibility

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import jwt from "jsonwebtoken";
-import { GraphQLError } from "graphql/error";
+import { GraphQLError } from "graphql/error/index.js";
 import dotenv from "dotenv";
 import { createError } from "../middleware/errorHandler.js";
 import { CONFIG } from "../constants/config.js";


### PR DESCRIPTION
- Change import to 'graphql/error/index.js' to resolve ERR_UNSUPPORTED_DIR_IMPORT error in Node ESM environments
- Ensures backend starts successfully on Render and other ESM platforms