### PR TITLE
Refactor seed and clean scripts for safer database management

### DIFF
--- a/client/src/features/rsvp/components/rsvpForm.tsx
+++ b/client/src/features/rsvp/components/rsvpForm.tsx
@@ -20,7 +20,7 @@ import { useRSVP } from '../hooks/useRSVP';
  */
 interface RSVPFormData {
   fullName: string;
-  attending: boolean;
+  attending: 'YES' | 'NO' | 'MAYBE';
   mealPreference: string;
   allergies?: string;
   additionalNotes?: string;
@@ -31,7 +31,7 @@ const RSVPForm = () => {
 
   const [formData, setFormData] = useState<RSVPFormData>({
     fullName: '',
-    attending: false,
+    attending: 'NO', // default to "NO" (enum string)
     mealPreference: '',
     allergies: '',
     additionalNotes: '',
@@ -71,7 +71,7 @@ const RSVPForm = () => {
     e.preventDefault();
 
     // Basic validation
-    if (!formData.fullName || typeof formData.attending !== 'boolean' || !formData.mealPreference) {
+    if (!formData.fullName || !formData.attending || !formData.mealPreference) {
       setErrorMessage('Please fill out all required fields.');
       return;
     }
@@ -84,7 +84,7 @@ const RSVPForm = () => {
       setSuccessMessage('RSVP submitted successfully!');
       setFormData({
         fullName: '',
-        attending: false,
+        attending: 'NO',
         mealPreference: '',
         allergies: '',
         additionalNotes: '',
@@ -107,8 +107,7 @@ const RSVPForm = () => {
     setErrorMessage('');
   };
 
-  const isFormIncomplete =
-    !formData.fullName || typeof formData.attending !== 'boolean' || !formData.mealPreference;
+  const isFormIncomplete = !formData.fullName || !formData.attending || !formData.mealPreference;
 
   return (
     <Box
@@ -144,14 +143,18 @@ const RSVPForm = () => {
         <Select
           labelId="attending-label"
           name="attending"
-          value={formData.attending ? 'yes' : 'no'}
+          value={formData.attending}
           onChange={(e) =>
-            setFormData((prev) => ({ ...prev, attending: e.target.value === 'yes' }))
+            setFormData((prev) => ({
+              ...prev,
+              attending: e.target.value as 'YES' | 'NO' | 'MAYBE',
+            }))
           }
           label="Attending?"
         >
-          <MenuItem value="yes">Yes</MenuItem>
-          <MenuItem value="no">No</MenuItem>
+          <MenuItem value="YES">Yes</MenuItem>
+          <MenuItem value="NO">No</MenuItem>
+          <MenuItem value="MAYBE">Maybe</MenuItem>
         </Select>
       </FormControl>
 

--- a/client/src/features/rsvp/pages/RSVP.tsx
+++ b/client/src/features/rsvp/pages/RSVP.tsx
@@ -27,7 +27,7 @@ const RSVPForm: React.FC = () => {
   // Local state for the RSVP form data, typed with RSVPFormData.
   const [formData, setFormData] = useState<RSVPFormData>({
     fullName: '',
-    attending: false,
+    attending: "NO", // default to "NO" (enum string)
     mealPreference: '',
     allergies: '',
     additionalNotes: '',
@@ -57,7 +57,7 @@ const RSVPForm: React.FC = () => {
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
-      [name]: value,
+      [name]: value as "YES" | "NO" | "MAYBE",
     }));
   };
 
@@ -69,7 +69,7 @@ const RSVPForm: React.FC = () => {
     e.preventDefault();
 
     // ✅ Basic form validation
-    if (!formData.fullName || typeof formData.attending !== 'boolean' || !formData.mealPreference) {
+    if (!formData.fullName || !formData.attending || !formData.mealPreference) {
       setErrorMessage('Please fill out all required fields, including meal preference.');
       return;
     }
@@ -83,7 +83,7 @@ const RSVPForm: React.FC = () => {
       setSuccessMessage('RSVP submitted successfully!');
       setFormData({
         fullName: '',
-        attending: false,
+        attending: "NO",
         mealPreference: '',
         allergies: '',
         additionalNotes: '',
@@ -143,14 +143,13 @@ const RSVPForm: React.FC = () => {
           <Select
             labelId="attending-label"
             name="attending"
-            value={formData.attending ? 'yes' : 'no'}
-            onChange={(e) =>
-              setFormData((prev) => ({ ...prev, attending: e.target.value === 'yes' }))
-            }
+            value={formData.attending}
+            onChange={handleSelectChange}
             label="Attending?"
           >
-            <MenuItem value="yes">Yes</MenuItem>
-            <MenuItem value="no">No</MenuItem>
+            <MenuItem value="YES">Yes</MenuItem>
+            <MenuItem value="NO">No</MenuItem>
+            <MenuItem value="MAYBE">Maybe</MenuItem>
           </Select>
         </FormControl>
 

--- a/client/src/features/rsvp/types/rsvpTypes.ts
+++ b/client/src/features/rsvp/types/rsvpTypes.ts
@@ -1,7 +1,7 @@
 export interface RSVP {
   _id: string;
   userId: string;
-  attending: boolean;
+  attending: "YES" | "NO" | "MAYBE";
   mealPreference: string;
   allergies?: string;
   additionalNotes?: string;
@@ -9,7 +9,7 @@ export interface RSVP {
 }
 
 export interface CreateRSVPInput {
-  attending: boolean;
+  attending: "YES" | "NO" | "MAYBE";
   mealPreference: string;
   allergies?: string;
   additionalNotes?: string;
@@ -17,7 +17,7 @@ export interface CreateRSVPInput {
 }
 
 export interface RSVPFormData {
-  attending: boolean;
+  attending: "YES" | "NO" | "MAYBE";
   mealPreference: string;
   allergies?: string;
   additionalNotes?: string;

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/src/server.js",
     "watch": "nodemon --watch src --exec \"tsx src/server.ts\"",
     "seed": "node dist/src/seeds/index.js",
+    "clean:db": "node dist/src/seeds/cleanDB.js",
     "test": "vitest"
   },
   "keywords": [],

--- a/server/src/seeds/seed.ts
+++ b/server/src/seeds/seed.ts
@@ -13,10 +13,6 @@ export const seedDatabase = async () => {
   try {
     console.log("🚀 Starting database seeding...");
 
-    // Clean up collections before seeding
-    await User.deleteMany({});
-    await RSVP.deleteMany({});
-
     // Read and parse user & RSVP data from JSON files
     const userData = JSON.parse(
       fs.readFileSync("./src/seeds/userData.json", "utf-8")


### PR DESCRIPTION
- Removed collection clean-up logic from seed.ts so seeding no longer deletes existing data
- Database cleaning is now handled exclusively by the clean:db script (cleanDB.ts)
- Ensures running `npm run seed` only adds/updates data, while `npm run clean:db` performs destructive cleanup