### PR TITLE
feat: Implement full user profile editing functionality

### DIFF
--- a/client/src/features/rsvp/graphql/mutations.ts
+++ b/client/src/features/rsvp/graphql/mutations.ts
@@ -75,3 +75,20 @@ export const DELETE_RSVP = gql`
     }
   }
 `;
+
+/**
+ * Edit an existing RSVP
+ */
+export const EDIT_RSVP = gql`
+  mutation EditRSVP($updates: RSVPInput!) {
+    editRSVP(updates: $updates) {
+      _id
+      userId
+      attending
+      mealPreference
+      allergies
+      additionalNotes
+      fullName
+    }
+  }
+`;

--- a/client/src/features/rsvp/types/rsvpTypes.ts
+++ b/client/src/features/rsvp/types/rsvpTypes.ts
@@ -1,7 +1,7 @@
 export interface RSVP {
   _id: string;
   userId: string;
-  attending: "YES" | "NO" | "MAYBE";
+  attending: 'YES' | 'NO' | 'MAYBE';
   mealPreference: string;
   allergies?: string;
   additionalNotes?: string;
@@ -9,7 +9,7 @@ export interface RSVP {
 }
 
 export interface CreateRSVPInput {
-  attending: "YES" | "NO" | "MAYBE";
+  attending: 'YES' | 'NO' | 'MAYBE';
   mealPreference: string;
   allergies?: string;
   additionalNotes?: string;
@@ -17,9 +17,16 @@ export interface CreateRSVPInput {
 }
 
 export interface RSVPFormData {
-  attending: "YES" | "NO" | "MAYBE";
+  attending: 'YES' | 'NO' | 'MAYBE';
   mealPreference: string;
   allergies?: string;
   additionalNotes?: string;
   fullName: string;
+}
+
+export interface RSVPInput {
+  attending: 'YES' | 'NO' | 'MAYBE';
+  mealPreference: string;
+  allergies?: string;
+  additionalNotes?: string;
 }

--- a/client/src/features/users/graphql/mutations.ts
+++ b/client/src/features/users/graphql/mutations.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const UPDATE_USER = gql`
-  mutation UpdateUser($id: ID!, $input: UpdateUserInput!) {
-    updateUser(id: $id, input: $input) {
+  mutation UpdateUser($input: UpdateUserInput!) {
+    updateUser(input: $input) {
       _id
       fullName
       email

--- a/client/src/features/users/hooks/useUsers.ts
+++ b/client/src/features/users/hooks/useUsers.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from '@apollo/client';
 import { GET_ME } from '../graphql/queries';
-import { UPDATE_USER, DELETE_USER } from '../graphql/mutations';
+import { DELETE_USER, UPDATE_USER } from '../graphql/mutations';
 import { UserType, UpdateUserInput } from '../types/userTypes';
 
 interface GetMeResponse {
@@ -27,20 +27,19 @@ export const useUsers = () => {
   // Mutation to update a user
   const [updateUserMutation] = useMutation<
     UpdateUserResponse,
-    { id: string; input: UpdateUserInput }
+    { input: UpdateUserInput }
   >(UPDATE_USER);
 
   // Mutation to delete a user
   const [deleteUserMutation] = useMutation<DeleteUserResponse, { id: string }>(DELETE_USER);
 
   /**
-   * Updates the user and refetches the latest profile data.
-   * @param id - The user ID to update.
+   * Updates the current user's profile information.
    * @param input - The updated user information.
    */
-  const updateUser = async (id: string, input: UpdateUserInput): Promise<void> => {
-    await updateUserMutation({ variables: { id, input } });
-    // Explicitly check before calling refetchUser to satisfy ESLint
+  const updateUser = async (input: UpdateUserInput): Promise<void> => {
+    await updateUserMutation({ variables: { input } });
+    // Refetch user data after update
     if (refetchUser) {
       refetchUser();
     }

--- a/client/src/features/users/pages/Profile.tsx
+++ b/client/src/features/users/pages/Profile.tsx
@@ -1,16 +1,31 @@
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
-import { Container, TextField, Button, Typography, CircularProgress, Alert } from '@mui/material';
-import { GET_ME } from '../../auth/graphql/queries';
+import {
+  Container,
+  TextField,
+  Typography,
+  CircularProgress,
+  Alert,
+  Button,
+  Box,
+  Card,
+  CardContent,
+  Divider,
+} from '@mui/material';
+import { GET_ME } from '../graphql/queries';
 import { UPDATE_USER } from '../graphql/mutations';
+import { UpdateUserInput } from '../types/userTypes';
 
-// Optional TypeScript interface for response
+// TypeScript interface for response matching the query
 interface MeResponse {
   me: {
     _id: string;
     email: string;
     fullName: string;
     isAdmin?: boolean;
+    hasRSVPed?: boolean;
+    rsvpId?: string;
+    isInvited?: boolean;
   };
 }
 
@@ -18,24 +33,37 @@ const Profile = () => {
   const { loading, data, refetch } = useQuery<MeResponse>(GET_ME);
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
+  const [editMode, setEditMode] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
   const [updateUser, { loading: updating }] = useMutation(UPDATE_USER, {
     onCompleted: () => {
-      setSuccessMessage('✅ Account updated successfully!');
+      setSuccessMessage('Profile updated successfully!');
+      setEditMode(false);
+      // Refetch to get the latest data
       refetch();
+      
+      // Clear success message after 3 seconds
+      setTimeout(() => {
+        setSuccessMessage('');
+      }, 3000);
     },
     onError: (error) => {
-      setErrorMessage(`❌ Error: ${error.message}`);
+      setErrorMessage(`Error: ${error.message}`);
+      
+      // Clear error message after 5 seconds
+      setTimeout(() => {
+        setErrorMessage('');
+      }, 5000);
     },
   });
 
   // Sync data to form inputs
   useEffect(() => {
     if (data?.me) {
-      setFullName(data.me.fullName);
-      setEmail(data.me.email);
+      setFullName(data.me.fullName || '');
+      setEmail(data.me.email || '');
     }
   }, [data]);
 
@@ -44,16 +72,38 @@ const Profile = () => {
       setSuccessMessage('');
       setErrorMessage('');
 
+      const updateData: UpdateUserInput = {};
+      if (fullName !== data?.me?.fullName) {
+        updateData.fullName = fullName;
+      }
+      if (email !== data?.me?.email) {
+        updateData.email = email;
+      }
+
+      // Only update if there are changes
+      if (Object.keys(updateData).length === 0) {
+        setEditMode(false);
+        return;
+      }
+
       await updateUser({
         variables: {
-          // Confirm your mutation input here!
-          fullName,
-          email,
-        },
+          input: updateData
+        }
       });
-    } catch (err) {
-      console.error('Error updating account:', err);
+    } catch (err: any) {
+      setErrorMessage(`Error updating account: ${err.message}`);
     }
+  };
+
+  const handleCancel = () => {
+    // Reset form fields to original data
+    if (data?.me) {
+      setFullName(data.me.fullName || '');
+      setEmail(data.me.email || '');
+    }
+    setEditMode(false);
+    setErrorMessage('');
   };
 
   if (loading) {
@@ -64,52 +114,115 @@ const Profile = () => {
     );
   }
 
-  const isFormIncomplete = !fullName || !email;
-
   return (
     <Container maxWidth="sm" sx={{ textAlign: 'center', marginTop: '50px' }}>
       <Typography variant="h4" gutterBottom>
         My Account
       </Typography>
       <Typography variant="subtitle1" gutterBottom>
-        Manage your account settings here.
+        {editMode ? 'Edit your profile information below.' : 'View your account details below.'}
       </Typography>
-
-      <TextField
-        fullWidth
-        label="Full Name"
-        value={fullName}
-        onChange={(e) => setFullName(e.target.value)}
-        sx={{ marginBottom: 3 }}
-      />
-      <TextField
-        fullWidth
-        label="Email"
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        sx={{ marginBottom: 3 }}
-      />
 
       {successMessage && (
         <Alert severity="success" sx={{ mb: 2 }}>
           {successMessage}
         </Alert>
       )}
+      
       {errorMessage && (
         <Alert severity="error" sx={{ mb: 2 }}>
           {errorMessage}
         </Alert>
       )}
 
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={handleUpdate}
-        disabled={updating || isFormIncomplete}
-      >
-        {updating ? <CircularProgress size={24} /> : 'Update Account'}
-      </Button>
+      <Card variant="outlined" sx={{ mb: 4 }}>
+        <CardContent>
+          {editMode ? (
+            <>
+              <TextField
+                fullWidth
+                label="Full Name"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                sx={{ marginBottom: 3 }}
+                required
+              />
+              <TextField
+                fullWidth
+                label="Email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                sx={{ marginBottom: 3 }}
+                required
+              />
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
+                <Button
+                  variant="outlined"
+                  onClick={handleCancel}
+                  disabled={updating}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleUpdate}
+                  disabled={updating || !fullName || !email}
+                >
+                  {updating ? <CircularProgress size={24} /> : 'Save Changes'}
+                </Button>
+              </Box>
+            </>
+          ) : (
+            <>
+              <Box sx={{ mb: 2 }}>
+                <Typography variant="subtitle2" color="textSecondary" align="left">
+                  Full Name
+                </Typography>
+                <Typography variant="body1" align="left">
+                  {data?.me?.fullName || 'Not available'}
+                </Typography>
+              </Box>
+
+              <Divider sx={{ my: 2 }} />
+
+              <Box sx={{ mb: 2 }}>
+                <Typography variant="subtitle2" color="textSecondary" align="left">
+                  Email Address
+                </Typography>
+                <Typography variant="body1" align="left">
+                  {data?.me?.email || 'Not available'}
+                </Typography>
+              </Box>
+
+              {data?.me?.hasRSVPed && (
+                <>
+                  <Divider sx={{ my: 2 }} />
+                  <Box sx={{ mb: 2 }}>
+                    <Typography variant="subtitle2" color="textSecondary" align="left">
+                      RSVP Status
+                    </Typography>
+                    <Typography variant="body1" align="left">
+                      You have submitted an RSVP
+                    </Typography>
+                  </Box>
+                </>
+              )}
+              
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 3 }}>
+                <Button 
+                  variant="contained" 
+                  color="primary" 
+                  onClick={() => setEditMode(true)}
+                >
+                  Edit Profile
+                </Button>
+              </Box>
+            </>
+          )}
+        </CardContent>
+      </Card>
     </Container>
   );
 };

--- a/client/src/features/users/services/userService.ts
+++ b/client/src/features/users/services/userService.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from '@apollo/client';
 import { GET_USERS, GET_USER_BY_ID } from '../graphql/queries';
-import { UPDATE_USER, DELETE_USER } from '../graphql/mutations';
+import { DELETE_USER, UPDATE_USER } from '../graphql/mutations';
 import { UserType, UpdateUserInput } from '../types/userTypes';
 
 interface GetUsersResponse {
@@ -9,10 +9,6 @@ interface GetUsersResponse {
 
 interface GetUserByIdResponse {
   getUserById: UserType;
-}
-
-interface UpdateUserResponse {
-  updateUser: UserType;
 }
 
 interface DeleteUserResponse {
@@ -39,27 +35,11 @@ export const useUsers = (userId?: string) => {
     variables: { id: userId },
   });
 
-  // Mutation for updating a user
-  const [updateUserMutation] = useMutation<
-    UpdateUserResponse,
-    { id: string; input: UpdateUserInput }
-  >(UPDATE_USER);
-
   // Mutation for deleting a user
   const [deleteUserMutation] = useMutation<DeleteUserResponse, { id: string }>(DELETE_USER);
 
-  /**
-   * Updates the user and refetches user data.
-   * @param id - The user ID.
-   * @param input - The update payload.
-   */
-  const updateUser = async (id: string, input: UpdateUserInput) => {
-    await updateUserMutation({ variables: { id, input } });
-    // Explicitly check and call refetchUser to satisfy ESLint rules
-    if (refetchUser) {
-      refetchUser();
-    }
-  };
+  // Mutation for updating a user
+  const [updateUserMutation] = useMutation<{ updateUser: UserType }, { input: UpdateUserInput }>(UPDATE_USER);
 
   /**
    * Deletes a user and refetches the user list.
@@ -70,13 +50,23 @@ export const useUsers = (userId?: string) => {
     refetchUsers();
   };
 
+  /**
+   * Updates a user's profile information.
+   * @param updateData - The data to update (fullName and/or email).
+   */
+  const updateUser = async (updateData: UpdateUserInput) => {
+    return await updateUserMutation({ 
+      variables: { input: updateData }
+    });
+  };
+
   return {
     allUsers: allUsersData?.getUsers || [],
     user: userByIdData?.getUserById || null,
     loading: usersLoading || userLoading,
     error: usersError || userError,
     refetchUsers,
-    updateUser,
     deleteUser,
+    updateUser,
   };
 };

--- a/client/src/features/users/types/userTypes.ts
+++ b/client/src/features/users/types/userTypes.ts
@@ -33,8 +33,6 @@ export interface CreateUserInput {
  * Input type for updating an existing user.
  */
 export interface UpdateUserInput {
-  _id: string; // ID of the user to update (required)
   fullName?: string;
   email?: string;
-  password?: string;
 }

--- a/server/src/graphql/resolvers.ts
+++ b/server/src/graphql/resolvers.ts
@@ -2,6 +2,7 @@ import {
   getUserById,
   createUser,
   authenticateUser,
+  updateUser,
 } from "../services/userService.js";
 
 // import invitedEmails from '../config/invitedList.js';
@@ -115,6 +116,26 @@ const resolvers = {
       } catch (error: any) {
         if (error.statusCode) throw error;
         throw createError(`Authentication failed: ${error.message}`, 401);
+      }
+    },
+
+    /**
+     * Updates the current user's profile information.
+     * @returns {Promise<User>} The updated user details.
+     */
+    updateUser: async (
+      _parent: any,
+      { input }: { input: { fullName?: string; email?: string } },
+      context: Context
+    ) => {
+      try {
+        if (!context.user)
+          throw new AuthenticationError("You must be logged in.");
+
+        return await updateUser(context.user._id, input);
+      } catch (error: any) {
+        if (error.statusCode) throw error;
+        throw createError(`User update failed: ${error.message}`, 400);
       }
     },
 

--- a/server/src/graphql/typeDefs.ts
+++ b/server/src/graphql/typeDefs.ts
@@ -51,6 +51,14 @@ const typeDefs = gql`
   }
 
   """
+  Input type for updating a user profile.
+  """
+  input UpdateUserInput {
+    fullName: String
+    email: String
+  }
+
+  """
   Query type for fetching user and RSVP details.
   """
   type Query {
@@ -63,6 +71,14 @@ const typeDefs = gql`
     Retrieves the RSVP of the authenticated user.
     """
     getRSVP: RSVP
+  }
+
+  """
+  Input type for updating user profile.
+  """
+  input UpdateUserInput {
+    fullName: String
+    email: String
   }
 
   """
@@ -82,6 +98,11 @@ const typeDefs = gql`
     Authenticates a user and returns a JWT token.
     """
     loginUser(email: String!, password: String!): AuthPayload
+
+    """
+    Updates the current user's profile information.
+    """
+    updateUser(input: UpdateUserInput!): User
 
     """
     Submits an RSVP for the authenticated user.


### PR DESCRIPTION
This commit adds the ability for users to edit their profile information from the My Account page.

Server-side changes:
- Add UpdateUserInput GraphQL type definition
- Implement updateUser mutation in schema and resolvers
- Create updateUser service function in userService.ts

Client-side changes:
- Restore profile editing UI with form fields and edit/save buttons
- Add proper state management for editing mode
- Implement UPDATE_USER GraphQL mutation
- Add UpdateUserInput type definition
- Handle success and error states with appropriate user feedback

The profile page now supports viewing user data and editing name and email information with proper validation and error handling.