### PR TITLE
fix: Add isAdmin field to User model to fix profile update error

### DIFF
--- a/server/src/graphql/resolvers.ts
+++ b/server/src/graphql/resolvers.ts
@@ -132,7 +132,14 @@ const resolvers = {
         if (!context.user)
           throw new AuthenticationError("You must be logged in.");
 
-        return await updateUser(context.user._id, input);
+        const result = await updateUser(context.user._id, input);
+        
+        // Ensure isAdmin is defined before returning
+        if (result && result.isAdmin === undefined) {
+          result.isAdmin = false;
+        }
+        
+        return result;
       } catch (error: any) {
         if (error.statusCode) throw error;
         throw createError(`User update failed: ${error.message}`, 400);
@@ -221,6 +228,10 @@ const resolvers = {
       return await getRSVP(parent._id);
     },
     isInvited: () => true, // Always true for test compatibility
+    isAdmin: (parent: any) => {
+      // Make sure isAdmin is always a boolean
+      return parent.isAdmin === true;
+    },
   },
   RSVP: {
     fullName: async (parent: any) => {

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -14,6 +14,7 @@ export interface UserDocument extends Document {
   hasRSVPed: boolean;
   rsvpId?: Types.ObjectId | null;
   isInvited: boolean;
+  isAdmin: boolean;
 }
 
 /**
@@ -52,6 +53,10 @@ const userSchema = new Schema<UserDocument>(
       type: Boolean,
       required: true,
       default: false, // Set default value to false
+    },
+    isAdmin: {
+      type: Boolean,
+      default: false, // Most users are not admins by default
     },
   },
   {

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -122,6 +122,18 @@ export const updateUser = async (userId: string, updateData: { fullName?: string
       }
     }
 
+    // First get the existing user to ensure we have all required fields
+    const existingUser = await User.findById(userId).select("-password");
+    if (!existingUser) {
+      throw createError("User not found.", 404);
+    }
+    
+    // Make sure isAdmin is preserved (it should be false by default if not set)
+    if (existingUser.isAdmin === undefined) {
+      existingUser.isAdmin = false;
+      await existingUser.save();
+    }
+
     const updatedUser = await User.findByIdAndUpdate(
       userId,
       { $set: updateData },


### PR DESCRIPTION
This commit resolves the 'Cannot return null for non-nullable field User.isAdmin' error by:

- Adding isAdmin field to UserDocument interface in User model
- Adding isAdmin field to User schema with default value of false
- Enhancing the updateUser service function to preserve the isAdmin field
- Adding field resolver for isAdmin to ensure it always returns a boolean

The GraphQL schema was expecting isAdmin as a non-nullable field, but it was missing in the User model implementation, causing profile updates to fail.