### PR TITLE
fix: Update user profile information in AuthContext when profile is e…

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -110,6 +110,17 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     localStorage.removeItem('user');
   };
 
+  /**
+   * Update user information in context and localStorage
+   */
+  const updateUserInfo = (userData: Partial<UserType>) => {
+    if (!user) return;
+    
+    const updatedUser = {...user, ...userData};
+    setUser(updatedUser);
+    localStorage.setItem('user', JSON.stringify(updatedUser));
+  };
+
   // Context value exposed to consumers
   const value: AuthContextType = {
     user,
@@ -117,6 +128,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     login,
     registerUser,
     logout,
+    updateUserInfo,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/client/src/features/users/pages/Profile.tsx
+++ b/client/src/features/users/pages/Profile.tsx
@@ -15,6 +15,7 @@ import {
 import { GET_ME } from '../graphql/queries';
 import { UPDATE_USER } from '../graphql/mutations';
 import { UpdateUserInput } from '../types/userTypes';
+import { useAuth } from '../../../context/AuthContext';
 
 // TypeScript interface for response matching the query
 interface MeResponse {
@@ -31,6 +32,7 @@ interface MeResponse {
 
 const Profile = () => {
   const { loading, data, refetch } = useQuery<MeResponse>(GET_ME);
+  const { updateUserInfo } = useAuth();
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
   const [editMode, setEditMode] = useState(false);
@@ -38,7 +40,15 @@ const Profile = () => {
   const [errorMessage, setErrorMessage] = useState('');
 
   const [updateUser, { loading: updating }] = useMutation(UPDATE_USER, {
-    onCompleted: () => {
+    onCompleted: (data) => {
+      // Update the user info in the AuthContext
+      if (data && data.updateUser) {
+        updateUserInfo({
+          fullName: data.updateUser.fullName,
+          email: data.updateUser.email
+        });
+      }
+      
       setSuccessMessage('Profile updated successfully!');
       setEditMode(false);
       // Refetch to get the latest data

--- a/client/src/features/users/types/userTypes.ts
+++ b/client/src/features/users/types/userTypes.ts
@@ -18,6 +18,7 @@ export interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   registerUser: (fullName: string, email: string, password: string) => Promise<void>;
   logout: () => void;
+  updateUserInfo: (userData: Partial<UserType>) => void;
 }
 
 /**


### PR DESCRIPTION
…dited

This commit fixes the issue where the user's name on dashboard headers wasn't updating after profile edits. Changes include:

- Add updateUserInfo method to AuthContextType
- Implement updateUserInfo function in AuthContext to update both context state and localStorage
- Update Profile component to call updateUserInfo after successful profile updates

This ensures that when a user edits their profile, the changes are immediately reflected throughout the application, including the dashboard welcome header.