### PR TITLE
fix: prevent navigation lockup by guarding AuthContext update in Dashboard

### DIFF
--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -1,11 +1,11 @@
 import React, { ReactElement } from 'react';
 import { Navigate } from 'react-router-dom';
-import { useAuth } from '../features/auth/hooks/useAuth';
+import { useAuth } from '../context/AuthContext';
 
 const PrivateRoute = ({ children }: { children: ReactElement }) => {
-  const { user } = useAuth(); // Assuming user is null when not logged in
+  const { isLoggedIn, user } = useAuth(); // Check both isLoggedIn and user
 
-  if (!user) {
+  if (!isLoggedIn || !user) {
     return <Navigate to="/login" replace />;
   }
 

--- a/client/src/features/dashboard/pages/Dashboard.tsx
+++ b/client/src/features/dashboard/pages/Dashboard.tsx
@@ -36,13 +36,17 @@ const Dashboard = () => {
   
   // Update local context when we get fresh data from server
   useEffect(() => {
-    if (meData?.me && user) {
+    if (
+      meData?.me &&
+      (meData.me.fullName !== user?.fullName || meData.me.email !== user?.email || meData.me.isAdmin !== user?.isAdmin)
+    ) {
       updateUserInfo({
         fullName: meData.me.fullName,
-        email: meData.me.email
+        email: meData.me.email,
+        isAdmin: meData.me.isAdmin
       });
     }
-  }, [meData, updateUserInfo, user]);
+  }, [meData, updateUserInfo]);
 
   // Now conditionally render UI if user data isn't ready.
   if (!user) {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Container, Typography, Button } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../features/auth/hooks/useAuth';
+import { useAuth } from '../context/AuthContext';
 import { useRSVP } from '../features/rsvp/hooks/useRSVP';
 
 const Home: React.FC = () => {


### PR DESCRIPTION
- Update Dashboard useEffect to only call updateUserInfo if user data from server differs from context user
- Remove user from dependency array to avoid infinite re-renders
- Resolves issue where navigation was blocked after login due to repeated context updates

This ensures navigation (Edit Profile, Manage RSVPs, sidebar links) works as expected after profile changes.